### PR TITLE
Feature - Average Game Rating

### DIFF
--- a/client/src/components/games/GameCard.jsx
+++ b/client/src/components/games/GameCard.jsx
@@ -5,7 +5,7 @@ const GameCard = ({ game }) => {
     return (
         <Card className="p-3 shadow-sm" outline color="light">
             <NavLink tag={RRNavLink} to={`${game.id}`}>
-                <CardTitle className="h5 mb-0">{game.title}</CardTitle>
+                <CardTitle className="h5 mb-0">{game.title} ({game.averageRating})</CardTitle>
             </NavLink>
             <CardText className="mb-1 mt-0">{game.designer}</CardText>
             <div className="d-flex flex-row gap-2">

--- a/client/src/components/games/GameCardDetailed.jsx
+++ b/client/src/components/games/GameCardDetailed.jsx
@@ -6,7 +6,7 @@ const GameCardDetailed = ({ game }) => {
     
     return (
         <Card className="p-3 shadow" outline color="light">
-            <CardTitle className="h5 mb-0">{game.title}</CardTitle>
+            <CardTitle className="h5 mb-0">{game.title} ({game.averageRating})</CardTitle>
             <CardText className="mb-1 mt-0">{game.designer} - {game.yearReleased}</CardText>
             <div className="d-flex flex-row gap-2">
                 {game.categories.map(c => (

--- a/client/src/pages/games/GameDetails.jsx
+++ b/client/src/pages/games/GameDetails.jsx
@@ -26,7 +26,7 @@ const GameDetails = () => {
             </div>
             <div className="w-75 mt-2">
                 <h3>Reviews</h3>
-                <div>
+                <div className="mb-3">
                     <Button onClick={() => navigate("review")}>Review Game</Button>
                 </div>
                 <ReviewListSub reviews={game.reviews} />

--- a/raterapi/models/game.py
+++ b/raterapi/models/game.py
@@ -17,5 +17,18 @@ class Game(models.Model):
         related_name="books"
     )
 
+    @property
+    def average_rating(self):
+        """Average rating calculated attribute for each game"""
+        ratings = self.ratings.all()
+
+        total_rating = 0
+        for rating in ratings:
+            total_rating += rating.rating
+
+        average_rating = round((total_rating / len(ratings)), 1)
+
+        return average_rating
+
     def __str__(self):
         return f"{self.title} by {self.designer}"

--- a/raterapi/models/rating.py
+++ b/raterapi/models/rating.py
@@ -5,7 +5,7 @@ from django.core.validators import MinValueValidator, MaxValueValidator
 
 class Rating(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-    game = models.ForeignKey(Game, on_delete=models.CASCADE)
+    game = models.ForeignKey(Game, on_delete=models.CASCADE, related_name="ratings")
     rating = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(10)])
 
     def __str__(self):

--- a/raterapi/views/games.py
+++ b/raterapi/views/games.py
@@ -13,6 +13,7 @@ class GameSerializer(serializers.ModelSerializer):
     ageRecommendation = serializers.SerializerMethodField()
     categories = CategorySerializer(many=True)
     reviews = ReviewSerializer(many=True, read_only=False)
+    averageRating = serializers.SerializerMethodField()
 
     def get_isOwner(self, obj):
         return self.context["request"].user == obj.user
@@ -29,11 +30,14 @@ class GameSerializer(serializers.ModelSerializer):
     def get_ageRecommendation(self, obj):
         return obj.age_recommendation
     
+    def get_averageRating(self, obj):
+        return obj.average_rating
+    
     class Meta:
         model = Game
         fields = [
-            "id", "title", "designer", "description", "yearReleased", "numberOfPlayers", 
-            "estimatedTimeToPlay", "ageRecommendation", "isOwner", "categories", "reviews"
+            "id", "title", "designer", "description", "yearReleased", "numberOfPlayers", "estimatedTimeToPlay", 
+            "ageRecommendation", "isOwner", "categories", "reviews", "averageRating"
         ]
 
 


### PR DESCRIPTION
### Purpose
To allow Users to see the average Rating of a Game

### Files Changed
- Added related name of "ratings" to the Game field in `rating.py`
- Added calculated property for average Rating in `game.py`
- Added average Rating field to Game serializer in `games.py`
- Added rendering for average Rating in `GameCard.jsx` and `GameCardDetailed.jsx`
- Added margin below the "Review Game" button in `GameDetails.jsx`

### To Test
Fetch, setup, create database using `seed_database.sh`, run debugger for backend, and run client using `npm run dev` in client directory, then confirm the following
- Game cards display their average Rating (max of 1 decimal place) next to their title in the Games List view
- The average Rating of the Game (max of 1 decimal place) is displayed next to their title in the Game Details view

closes #8